### PR TITLE
Faster ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+sudo: false
 language: go
-
 go:
-  - tip
+- 1.4
+- tip
 
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/mandrill.go
+++ b/mandrill.go
@@ -29,8 +29,8 @@
 //
 // http://help.mandrill.com/entries/21678522-How-do-I-use-merge-tags-to-add-dynamic-content-
 //
-//     message.GlobalMergeVars := mandrill.ConvertMapToVariables(map[string]string{"name": "Bob"})
-//     message.MergeVars := mandrill.ConvertMapToVariablesForRecipient("bob@example.com", map[string]string{"name": "Bob"})
+//     message.GlobalMergeVars := mandrill.ConvertMapToVariables(map[string]interface{}{"name": "Bob"})
+//     message.MergeVars := mandrill.ConvertMapToVariablesForRecipient("bob@example.com", map[string]interface{}{"name": "Bob"})
 //
 // Integration Testing Keys
 
@@ -166,7 +166,7 @@ type RcptMetadata struct {
 	// the email address of the recipient that the metadata is associated with
 	Rcpt string `json:"rcpt"`
 	// an associated array containing the recipient's unique metadata. If a key exists in both the per-recipient metadata and the global metadata, the per-recipient metadata will be used.
-	Values map[string]string `json:"values"`
+	Values map[string]interface{} `json:"values"`
 }
 
 // Attachment represents a single supported attachment
@@ -243,7 +243,7 @@ func (c *Client) MessagesSend(message *Message) (responses []*Response, err erro
 }
 
 // MessagesSendTemplate sends a message using a Mandrill template
-func (c *Client) MessagesSendTemplate(message *Message, templateName string, contents map[string]string) (responses []*Response, err error) {
+func (c *Client) MessagesSendTemplate(message *Message, templateName string, contents map[string]interface{}) (responses []*Response, err error) {
 
 	var data struct {
 		Key             string      `json:"key"`
@@ -311,7 +311,7 @@ func (m *Message) AddRecipient(email string, name string, sendType string) {
 }
 
 // ConvertMapToVariables converts a regular string/string map into the Variable struct
-func ConvertMapToVariables(m map[string]string) []*Variable {
+func ConvertMapToVariables(m map[string]interface{}) []*Variable {
 	variables := make([]*Variable, 0, len(m))
 	for k, v := range m {
 		variables = append(variables, &Variable{k, v})
@@ -321,17 +321,17 @@ func ConvertMapToVariables(m map[string]string) []*Variable {
 
 // MapToVars converts a regular string/string map into the Variable struct
 // Alias of `ConvertMapToVariables`
-func MapToVars(m map[string]string) []*Variable {
+func MapToVars(m map[string]interface{}) []*Variable {
 	return ConvertMapToVariables(m)
 }
 
 // ConvertMapToVariablesForRecipient converts a regular string/string map into the RcptMergeVars struct
-func ConvertMapToVariablesForRecipient(email string, m map[string]string) *RcptMergeVars {
+func ConvertMapToVariablesForRecipient(email string, m map[string]interface{}) *RcptMergeVars {
 	return &RcptMergeVars{Rcpt: email, Vars: ConvertMapToVariables(m)}
 }
 
 // MapToRecipientVars converts a regular string/string map into the RcptMergeVars struct
 // Alias of `ConvertMapToVariablesForRecipient`
-func MapToRecipientVars(email string, m map[string]string) *RcptMergeVars {
+func MapToRecipientVars(email string, m map[string]interface{}) *RcptMergeVars {
 	return ConvertMapToVariablesForRecipient(email, m)
 }

--- a/mandrill.go
+++ b/mandrill.go
@@ -243,7 +243,7 @@ func (c *Client) MessagesSend(message *Message) (responses []*Response, err erro
 }
 
 // MessagesSendTemplate sends a message using a Mandrill template
-func (c *Client) MessagesSendTemplate(message *Message, templateName string, contents map[string]interface{}) (responses []*Response, err error) {
+func (c *Client) MessagesSendTemplate(message *Message, templateName string, contents interface{}) (responses []*Response, err error) {
 
 	var data struct {
 		Key             string      `json:"key"`
@@ -311,8 +311,13 @@ func (m *Message) AddRecipient(email string, name string, sendType string) {
 }
 
 // ConvertMapToVariables converts a regular string/string map into the Variable struct
-func ConvertMapToVariables(m map[string]interface{}) []*Variable {
+func ConvertMapToVariables(i interface{}) []*Variable {
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return nil
+	}
 	variables := make([]*Variable, 0, len(m))
+
 	for k, v := range m {
 		variables = append(variables, &Variable{k, v})
 	}
@@ -321,17 +326,17 @@ func ConvertMapToVariables(m map[string]interface{}) []*Variable {
 
 // MapToVars converts a regular string/string map into the Variable struct
 // Alias of `ConvertMapToVariables`
-func MapToVars(m map[string]interface{}) []*Variable {
+func MapToVars(m interface{}) []*Variable {
 	return ConvertMapToVariables(m)
 }
 
 // ConvertMapToVariablesForRecipient converts a regular string/string map into the RcptMergeVars struct
-func ConvertMapToVariablesForRecipient(email string, m map[string]interface{}) *RcptMergeVars {
+func ConvertMapToVariablesForRecipient(email string, m interface{}) *RcptMergeVars {
 	return &RcptMergeVars{Rcpt: email, Vars: ConvertMapToVariables(m)}
 }
 
 // MapToRecipientVars converts a regular string/string map into the RcptMergeVars struct
 // Alias of `ConvertMapToVariablesForRecipient`
-func MapToRecipientVars(email string, m map[string]interface{}) *RcptMergeVars {
+func MapToRecipientVars(email string, m interface{}) *RcptMergeVars {
 	return ConvertMapToVariablesForRecipient(email, m)
 }

--- a/mandrill_test.go
+++ b/mandrill_test.go
@@ -143,14 +143,14 @@ func Test_AddRecipient(t *testing.T) {
 // ConvertMapToVariables /////
 
 func Test_ConvertMapToVariables(t *testing.T) {
-	m := map[string]string{"name": "bob"}
+	m := map[string]interface{}{"name": "bob"}
 	target := ConvertMapToVariables(m)
 	hand := []*Variable{&Variable{"name", "bob"}}
 	expect(t, reflect.DeepEqual(target, hand), true)
 }
 
 func Test_MapToVars(t *testing.T) {
-	m := map[string]string{"name": "bob"}
+	m := map[string]interface{}{"name": "bob"}
 	target := MapToVars(m)
 	hand := []*Variable{&Variable{"name", "bob"}}
 	expect(t, reflect.DeepEqual(target, hand), true)


### PR DESCRIPTION
Using containers makes small test suites like this one run way faster.
Also added testing against current stable version of Go in addition to tip.
