### PR TITLE
Fix backwards incompatibility.

### DIFF
--- a/mandrill.go
+++ b/mandrill.go
@@ -312,10 +312,20 @@ func (m *Message) AddRecipient(email string, name string, sendType string) {
 
 // ConvertMapToVariables converts a regular string/string map into the Variable struct
 func ConvertMapToVariables(i interface{}) []*Variable {
-	m, ok := i.(map[string]interface{})
-	if !ok {
+
+	var m map[string]interface{}
+	switch temp := i.(type) {
+	case map[string]interface{}:
+		m = temp
+	case map[string]string:
+		m = make(map[string]interface{}, len(temp))
+		for k, v := range temp {
+			m[k] = v
+		}
+	default:
 		return nil
 	}
+
 	variables := make([]*Variable, 0, len(m))
 
 	for k, v := range m {

--- a/mandrill_test.go
+++ b/mandrill_test.go
@@ -136,7 +136,7 @@ func Test_SANDBOX_ERROR(t *testing.T) {
 func Test_AddRecipient(t *testing.T) {
 	m := &Message{}
 	m.AddRecipient("bob@example.com", "Bob Johnson", "to")
-	tos := []*To{&To{"bob@example.com", "Bob Johnson", "to"}}
+	tos := []*To{{"bob@example.com", "Bob Johnson", "to"}}
 	expect(t, reflect.DeepEqual(m.To, tos), true)
 }
 
@@ -145,14 +145,24 @@ func Test_AddRecipient(t *testing.T) {
 func Test_ConvertMapToVariables(t *testing.T) {
 	m := map[string]interface{}{"name": "bob"}
 	target := ConvertMapToVariables(m)
-	hand := []*Variable{&Variable{"name", "bob"}}
+	hand := []*Variable{{"name", "bob"}}
+	expect(t, reflect.DeepEqual(target, hand), true)
+
+	ms := map[string]string{"name": "bob"}
+	target = ConvertMapToVariables(ms)
+	hand = []*Variable{{"name", "bob"}}
 	expect(t, reflect.DeepEqual(target, hand), true)
 }
 
 func Test_MapToVars(t *testing.T) {
 	m := map[string]interface{}{"name": "bob"}
 	target := MapToVars(m)
-	hand := []*Variable{&Variable{"name", "bob"}}
+	hand := []*Variable{{"name", "bob"}}
+	expect(t, reflect.DeepEqual(target, hand), true)
+
+	ms := map[string]interface{}{"name": "bob"}
+	target = MapToVars(ms)
+	hand = []*Variable{{"name", "bob"}}
 	expect(t, reflect.DeepEqual(target, hand), true)
 }
 


### PR DESCRIPTION
Previously, the `ConvertMapToVariables` and `MapToVars` functions expected `map[string]string`. A recent change switched this to expecting `interface{}`, which was supposed to be backward compatible with the `map[string]string` while encouraging/allowing `map[string]interface{}`. The change was incomplete, as it only checked for `map[string]interface{}` and aborted if it was not of that type. This PR fixes this oversight.
