### PR TITLE
Fixing SANDBOX_ERROR documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can pass special API keys to the client to mock success/err responses from `
 c := ClientWithKey("SANDBOX_SUCCESS")
 
 // Sending messages will error, but without a real API request
-c := ClientWithKey("SANDBOX_SUCCESS")
+c := ClientWithKey("SANDBOX_ERROR")
 ```
 
 

--- a/mandrill.go
+++ b/mandrill.go
@@ -40,7 +40,7 @@
 //     c := ClientWithKey("SANDBOX_SUCCESS")
 
 //     // Sending messages will error, but without a real API request
-//     c := ClientWithKey("SANDBOX_SUCCESS")
+//     c := ClientWithKey("SANDBOX_ERROR")
 
 package mandrill
 
@@ -276,7 +276,7 @@ func (c *Client) sendMessagePayload(data interface{}, path string) (responses []
 	}
 
 	if c.Key == "SANDBOX_ERROR" {
-		return nil, errors.New("SANDBOX_SUCCESS")
+		return nil, errors.New("SANDBOX_ERROR")
 	}
 
 	payload, _ := json.Marshal(data)


### PR DESCRIPTION
- and returning "SANDBOX_ERROR" when the sandbox errors instead of "SANDBOX_SUCCESS"
